### PR TITLE
Implement FrontendOptimizer and basic tests

### DIFF
--- a/core/optimization.py
+++ b/core/optimization.py
@@ -1,0 +1,50 @@
+"""Frontend optimization utilities.
+
+This module provides basic code analysis and optimization helpers
+for frontend projects.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+
+class FrontendOptimizer:
+    """Simple optimizer for frontend code.
+
+    Currently provides very small-scale optimizations such as
+    JavaScript and CSS minification or basic HTML audits.
+    """
+
+    def minify_js(self, code: str) -> str:
+        """Minify JavaScript code using naive rules."""
+        # Remove single line comments
+        code = re.sub(r"//.*?(?=\n|$)", "", code)
+        # Remove block comments
+        code = re.sub(r"/\*.*?\*/", "", code, flags=re.S)
+        # Collapse whitespace
+        code = re.sub(r"\s+", " ", code)
+        return code.strip()
+
+    def minify_css(self, code: str) -> str:
+        """Minify CSS code using naive rules."""
+        code = re.sub(r"/\*.*?\*/", "", code, flags=re.S)
+        code = re.sub(r"\s+", " ", code)
+        code = re.sub(r"\s*([{}:;,])\s*", r"\1", code)
+        return code.strip()
+
+    def audit_html(self, code: str) -> List[str]:
+        """Return a list of basic audit issues for HTML code."""
+        issues: List[str] = []
+        for match in re.finditer(r"<img\b(?![^>]*\balt=)[^>]*>", code, flags=re.I):
+            issues.append(f"Imagen sin alt en posición {match.start()}")
+        return issues
+
+    def optimize(self, code: str, language: str = "js") -> str:
+        """Optimize code according to language."""
+        if language == "js":
+            return self.minify_js(code)
+        if language == "css":
+            return self.minify_css(code)
+        return code

--- a/genesis_frontend/__init__.py
+++ b/genesis_frontend/__init__.py
@@ -1,0 +1,14 @@
+"""Compatibility wrapper for the genesis_frontend package used in tests."""
+import importlib.util
+import sys
+from pathlib import Path
+
+_package_root = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location(
+    __name__,
+    _package_root / "__init__.py",
+    submodule_search_locations=[str(_package_root)],
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules[__name__] = module
+spec.loader.exec_module(module)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,9 @@
+from genesis_frontend.core import FrontendOptimizer
+
+
+def test_optimize_js():
+    optimizer = FrontendOptimizer()
+    code = "function add(a, b) { // comment\n return a + b; }"
+    result = optimizer.optimize(code, language="js")
+    assert "//" not in result
+    assert "\n" not in result


### PR DESCRIPTION
## Summary
- add `FrontendOptimizer` with simple JS/CSS minification and HTML audit helpers
- provide wrapper package `genesis_frontend` for tests
- add unit test covering optimizer

## Testing
- `pytest -c /dev/null --import-mode=importlib tests/test_optimizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882791b08e48325a13f2d5079522802